### PR TITLE
Release - ISLE v1.1.1 - Security update March 2019

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM islandoracollabgroup/isle-tomcat:serverjre8
+FROM islandoracollabgroup/isle-tomcat:1.1.1
 
 ## Dependencies 
 RUN GEN_DEP_PACKS="ffmpeg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN BUILD_DEPS="build-essential \
 
 ## Djatoka
 RUN cd /tmp && \
-    curl -O https://sourceforge.mirrorservice.org/d/dj/djatoka/djatoka/1.1/adore-djatoka-1.1.tar.gz && \
+    curl -LO http://downloads.sourceforge.net/project/djatoka/djatoka/1.1/adore-djatoka-1.1.tar.gz && \
     tar -xzf adore-djatoka-1.1.tar.gz -C /usr/local && \
     ln -s /usr/local/adore-djatoka-1.1/bin/Linux-x86-64/kdu_compress /usr/local/bin/kdu_compress && \
     ln -s /usr/local/adore-djatoka-1.1/bin/Linux-x86-64/kdu_expand /usr/local/bin/kdu_expand && \


### PR DESCRIPTION
* Server package management updates via `apt-get`
* Updated `GEN_DEP_PACKS` dependencies via `apt-get`
* Updated `openjpeg` to [Dec 21,2018 commit](https://github.com/uclouvain/openjpeg/commit/51f097e6d5754ddae93e716276fe8176b44ec548)
* Upgraded Imagemagick to `7.0.8-34`