### PR TITLE
Updates for ISLE 1.4.0 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM islandoracollabgroup/isle-tomcat:1.3.0
+FROM islandoracollabgroup/isle-tomcat:1.4.0
 
 # Set up environmental variables for tomcat & dependencies
 ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \


### PR DESCRIPTION
Updates base image to pulling isle-tomcat 1.4.0.  
Will update system elements via apt-get.  Also will pull the latest ImageMagick (currently 7.0.9-4) and OpenJpeg ([commit](https://github.com/uclouvain/openjpeg/commit/ac3737372a00b8778b528094dd5bd58a74f67d42)).