### PR TITLE
ISLE-v.1.5.1 Release - Security & software updates. Readme fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM islandoracollabgroup/isle-tomcat:1.5.0
+#FROM islandoracollabgroup/isle-tomcat:1.5.0
+FROM borndigital/isle-tomcat:1.5.1-dev
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/
@@ -6,14 +7,11 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     JAVA_MIN_MEM=${JAVA_MIN_MEM:-0} \
     ## Per Gavin, we are no longer using -XX:+UseConcMarkSweepGC, instead G1GC.
     JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70' \
-    KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
-    KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \
     CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
     -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
-    -Dkakadu.home=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     -Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
     -DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
-    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.5}
+    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.6}
 
 
 ## Dependencies 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     JAVA_MIN_MEM=${JAVA_MIN_MEM:-0} \
     ## Per Gavin, we are no longer using -XX:+UseConcMarkSweepGC, instead G1GC.
     ## # To use Kakadu for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
-    JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70' \
+    #JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70' \
+    JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
     CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" \
     # To use Kakadu for uniqe builds - uncomment this below and comment out the above code.
     #KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,18 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     ## # To use Kakadu instead of OpenJpeg as the processor for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
     JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
     CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
+    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
     -Djava.library.path=/usr/local/lib:/usr/local/tomcat/lib \
-    -DLD_LIBRARY_PATH=/usr/local/lib:/usr/local/tomcat/lib \
-    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"    
+    -DLD_LIBRARY_PATH=/usr/local/lib:/usr/local/tomcat/lib"
     ## # To use Kakadu instead of OpenJpeg as the processor for unique builds - uncomment this below and comment out the above code.
     #KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     #KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \
+    #JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
     #CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
     #-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
     #-Dkakadu.home=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     #-Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
-    #-DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
+    #-DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib"
 
 
 ## Dependencies 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,15 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
     -Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
     -DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
-    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.6}
+    # To use Kakadu for uniqe builds - uncomment this below and comment out the above code.
+    #KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
+    #KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \
+    #CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
+    #-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
+    #-Dkakadu.home=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
+    #-Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
+    #-DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
+    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.6} 
 
 
 ## Dependencies 
@@ -88,11 +96,12 @@ RUN cd /tmp && \
     rm cantaloupe-$CANTALOUPE_VERSION/*.sample && \
     mkdir -p /usr/local/cantaloupe /usr/local/cantaloupe/temp /usr/local/cantaloupe/cache /usr/local/tomcat/logs/cantaloupe && \
     cp -r cantaloupe-$CANTALOUPE_VERSION/* /usr/local/cantaloupe && \
-    chmod 755 /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand && \
-    ln -s /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand /usr/local/bin/kdu_expand && \
-    ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_a7AR.so /usr/local/lib/libkdu_a7AR.so && \
-    ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_jni.so /usr/local/lib/libkdu_jni.so && \
-    ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_v7AR.so /usr/local/lib/libkdu_v7AR.so && \
+    # Uncomment here to use the Kakadu demo or licensed processor
+    # chmod 755 /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand && \
+    # ln -s /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand /usr/local/bin/kdu_expand && \
+    # ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_a7AR.so /usr/local/lib/libkdu_a7AR.so && \
+    # ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_jni.so /usr/local/lib/libkdu_jni.so && \
+    # ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_v7AR.so /usr/local/lib/libkdu_v7AR.so && \
     mv /usr/local/cantaloupe/cantaloupe-$CANTALOUPE_VERSION.war /usr/local/tomcat/webapps/cantaloupe.war && \
     unzip /usr/local/tomcat/webapps/cantaloupe.war -d /usr/local/tomcat/webapps/cantaloupe && \
     chown tomcat /usr/local/cantaloupe -R && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM islandoracollabgroup/isle-tomcat:1.5.0
-FROM borndigital/isle-tomcat:1.5.1-dev
+FROM islandoracollabgroup/isle-tomcat:1.5.1
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,9 @@ FROM borndigital/isle-tomcat:1.5.1-dev
 ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     JAVA_MIN_MEM=${JAVA_MIN_MEM:-0} \
     ## Per Gavin, we are no longer using -XX:+UseConcMarkSweepGC, instead G1GC.
+    ## # To use Kakadu for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
     JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70' \
-    CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
-    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
-    -Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
-    -DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
+    CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" \
     # To use Kakadu for uniqe builds - uncomment this below and comment out the above code.
     #KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     #KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ FROM borndigital/isle-tomcat:1.5.1-dev
 # @see: Cantaloupe https://cantaloupe-project.github.io/
 ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     JAVA_MIN_MEM=${JAVA_MIN_MEM:-0} \
-    ## Per Gavin, we are no longer using -XX:+UseConcMarkSweepGC, instead G1GC.
-    ## # To use Kakadu for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
-    #JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70' \
+    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.6} \
+    ## # To use Kakadu instead of OpenJpeg as the processor for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
     JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
-    CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true" \
-    # To use Kakadu for uniqe builds - uncomment this below and comment out the above code.
+    CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
+    -Djava.library.path=/usr/local/lib:/usr/local/tomcat/lib \
+    -DLD_LIBRARY_PATH=/usr/local/lib:/usr/local/tomcat/lib \
+    -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"    
+    ## # To use Kakadu instead of OpenJpeg as the processor for unique builds - uncomment this below and comment out the above code.
     #KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     #KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \
     #CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
@@ -18,7 +20,6 @@ ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     #-Dkakadu.home=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
     #-Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
     #-DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib" \
-    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.6} 
 
 
 ## Dependencies 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,85 @@
 Running Cantaloupe as a IIIF compliant image server for ISLE.
 
 Based on:
-  - [ISLE-tomcat](https://github.com/Islandora-Collaboration-Group/isle-tomcat)
-  - [Cantaloupe 4.1.5](https://medusa-project.github.io/cantaloupe/) an IIIF compliant open-source dynamic image server
+* [ISLE-tomcat](https://github.com/Islandora-Collaboration-Group/isle-tomcat)
+* [Cantaloupe 4.1.6](https://medusa-project.github.io/cantaloupe/) an IIIF compliant open-source dynamic image server
 
 Contains and Includes:
-  - [ImageMagick 7](https://www.imagemagick.org/)
-    - Features: Cipher DPC HDRI OpenMP
-    - Delegates (built-in): bzlib djvu mpeg fontconfig freetype jbig jng jpeg lcms lqr lzma openexr openjp2 png ps raw rsvg tiff webp wmf x zlib
-  - [OpenJPEG](http://www.openjpeg.org/)
-  - [FFmepg](https://www.ffmpeg.org/)
+* [ImageMagick 7](https://www.imagemagick.org/)
+  * Features: Cipher DPC HDRI OpenMP
+  * Delegates (built-in): bzlib djvu mpeg fontconfig freetype jbig jng jpeg lcms lqr lzma openexr openjp2 png ps raw rsvg tiff webp wmf x zlib
+* [OpenJPEG](http://www.openjpeg.org/)
+* [FFmepg](https://www.ffmpeg.org/)
 
 ## Usage
 
 * For general usage of this image and [ISLE](https://github.com/Islandora-Collaboration-Group/ISLE), please refer to [ISLE documentation](https://islandora-collaboration-group.github.io/ISLE/)
+
+---
+
+### (Manual - Docker image build process for Kakadu)
+* **Please note:** As of ISLE release 1.5.1, the demo Kakadu binaries, libraries and paths are no longer used in the compiling of the `isle-imageservices` Docker image. If you require them, you will need to do the following:
+
+#### Dockerfile
+
+* Within the `Dockerfile`: comment out the following lines, e.g. add a `#` in front of those lines and save the file.
+
+```bash
+JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
+CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
+-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
+-Djava.library.path=/usr/local/lib:/usr/local/tomcat/lib \
+-DLD_LIBRARY_PATH=/usr/local/lib:/usr/local/tomcat/lib"
+```
+
+* Within the `Dockerfile`: uncomment the following lines and save the file.
+
+```bash
+#KAKADU_HOME=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
+#KAKADU_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib \
+#JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
+#CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
+#-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true \
+#-Dkakadu.home=/usr/local/cantaloupe/deps/Linux-x86-64/bin \
+#-Djava.library.path=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib \
+#-DLD_LIBRARY_PATH=/usr/local/cantaloupe/deps/Linux-x86-64/lib:/usr/local/tomcat/lib"
+```
+
+* Within the Dockerfile, uncomment the following lines and save the file.
+
+```bash
+# chmod 755 /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand && \
+# ln -s /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand /usr/local/bin/kdu_expand && \
+# ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_a7AR.so /usr/local/lib/libkdu_a7AR.so && \
+# ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_jni.so /usr/local/lib/libkdu_jni.so && \
+# ln -s /usr/local/cantaloupe/deps/Linux-x86-64/lib/libkdu_v7AR.so /usr/local/lib/libkdu_v7AR.so && \
+```    
+
+#### Changes to files within the rootfs directory
+
+* Within the following two files, edit the following: 
+  * `rootfs/usr/local/cantaloupe/cantaloupe.properties`
+  * `rootfs/etc/confd/templates/imageserv/cantaloupe.properties.tpl`
+    * Find this line `KakaduDemoProcessor.path_to_binaries = `
+    * add the path to the KaduDemoProcessor or paid Kakadu Processor binaries.
+    * save the file.
+
+* Within `rootfs/fix-attrs.d/11-cantaloupe`, edi the following:
+  * Uncomment the following `# /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand true tomcat 0755`
+  * save the file
+
+* Once finished, check in your changes into a new git repository.
+
+#### Manual build process
+
+* Open a terminal and either clone down this new git repository to your local laptop or `cd` to the project on your laptop
+
+* Build the image
+  * `docker build -t yourdockerimagerepohere/isle-imageservices:1.5.1 .`
+
+* Push the image to your docker image repo
+  * `docker push yourdockerimagerepohere/isle-imageservices:1.5.1`
+
+* Use the newly built image in ISLE
+  * Within all of the `docker-compose.*.yml` files in your ISLE project, change `image: islandoracollabgroup/isle-imageservices:1.5.1` to `image: yourdockerimagerepohere/isle-imageservices:1.5.1`
+  * Save all of the files after editing and check the changes into git.

--- a/rootfs/etc/fix-attrs.d/11-cantaloupe
+++ b/rootfs/etc/fix-attrs.d/11-cantaloupe
@@ -1,2 +1,4 @@
 /usr/local/cantaloupe true tomcat 0644 0755
-/usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand true tomcat 0755
+
+# Uncomment this line for use of Kakadu
+# /usr/local/cantaloupe/deps/Linux-x86-64/bin/kdu_expand true tomcat 0755

--- a/rootfs/usr/local/cantaloupe/cantaloupe.properties
+++ b/rootfs/usr/local/cantaloupe/cantaloupe.properties
@@ -695,7 +695,7 @@ log.application.ConsoleAppender.enabled = true
 log.application.FileAppender.enabled = false
 log.application.FileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/cantaloupe.log
 
-log.application.RollingFileAppender.enabled = true
+log.application.RollingFileAppender.enabled = false
 log.application.RollingFileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/cantaloupe.log
 log.application.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.application.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/tomcat/logs/cantaloupe/cantaloupe-%d{yyyy-MM-dd}.log
@@ -719,7 +719,7 @@ log.application.SyslogAppender.facility = LOCAL0
 log.error.FileAppender.enabled = false
 log.error.FileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/cantaloupe.error.log
 
-log.error.RollingFileAppender.enabled = true
+log.error.RollingFileAppender.enabled = false
 log.error.RollingFileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/cantaloupe.error.log
 log.error.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.error.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/tomcat/logs/cantaloupe/cantaloupe.error-%d{yyyy-MM-dd}.log
@@ -737,7 +737,7 @@ log.access.FileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/access-cant
 
 # RollingFileAppender is an alternative to using something like
 # FileAppender + logrotate.
-log.access.RollingFileAppender.enabled = true
+log.access.RollingFileAppender.enabled = false
 log.access.RollingFileAppender.pathname = /usr/local/tomcat/logs/cantaloupe/access-cantaloupe.log
 log.access.RollingFileAppender.policy = TimeBasedRollingPolicy
 log.access.RollingFileAppender.TimeBasedRollingPolicy.filename_pattern = /usr/local/tomcat/logs/cantaloupe/access-cantaloupe.log-%d{yyyy-MM-dd}.log


### PR DESCRIPTION
* ISLE Tomcat base image upgrade from 1.5.0 to 1.5.1
  * `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `Cantaloupe` upgraded to version `4.1.6`
  * Kakadu symlinks removed
* `ImageMagick` upgraded to version `7.0.10-24`
* `OpenJpeg` upgraded to [commit / hash](https://github.com/uclouvain/openjpeg/commit/cbee7891a0ee664dd83ca09553d2e30da716a883) June 30th, 2020 (v. 2.3.1)  