### PR TITLE
ISLE-v.1.5.2 Release - Sec updates, S6 Overlay upgrade, ImageMagick & OpenJpeg upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM islandoracollabgroup/isle-tomcat:1.5.1
+#FROM islandoracollabgroup/isle-tomcat:1.5.2
+FROM borndigital/isle-tomcat:1.5.2
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/
@@ -115,7 +116,7 @@ ARG VCS_REF
 ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.name="ISLE Image Services" \
-      org.label-schema.description="Serving all your images needs." \
+      org.label-schema.description="Serving all your images needs with IIIF & Cantaloupe." \
       org.label-schema.url="https://islandora-collaboration-group.github.io" \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/Islandora-Collaboration-Group/isle-imageservices" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM islandoracollabgroup/isle-tomcat:1.5.2
-FROM borndigital/isle-tomcat:1.5.2
+FROM borndigital/isle-tomcat:1.5.2-dev
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM islandoracollabgroup/isle-tomcat:1.5.2
-FROM borndigital/isle-tomcat:1.5.2-dev
+FROM islandoracollabgroup/isle-tomcat:1.5.2
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/


### PR DESCRIPTION
* ISLE Tomcat base image upgrade from 1.5.1 to 1.5.2
  * `adoptopenjdk/openjdk8` base image (sec updates)
* `apt-get` dist-upgrades for dependencies (sec updates)
* `ImageMagick` upgraded to version `7.0.10-29`
* `OpenJpeg` upgraded to [commit / hash](https://github.com/uclouvain/openjpeg/commit/0f16986738725799237548ce6a2ea12516850e72) September 16th, 2020 (v. 2.3.1)  