### PR TITLE
ISLE-v.1.5.5 Release - Base image update, GA, Sec updates, Cantaloupe, Image-Magick & OpenJPEG upgrades

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -41,7 +41,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_ORG }}/isle-imageservices:1.5.4
+            ${{ secrets.DOCKERHUB_ORG }}/isle-imageservices:1.5.5
             ${{ secrets.DOCKERHUB_ORG }}/isle-imageservices:latest
       -
         name: Image digest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# FROM islandoracollabgroup/isle-tomcat:1.5.5
-FROM borndigital/isle-tomcat:1.5.5
+FROM islandoracollabgroup/isle-tomcat:1.5.5
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM islandoracollabgroup/isle-tomcat:1.5.4
+# FROM islandoracollabgroup/isle-tomcat:1.5.5
+FROM borndigital/isle-tomcat:1.5.5
 
 # Set up environmental variables for Tomcat, Cantaloupe & dependencies
 # @see: Cantaloupe https://cantaloupe-project.github.io/
 # @see: ImageMagick https://github.com/ImageMagick/ImageMagick/releases
 ENV JAVA_MAX_MEM=${JAVA_MAX_MEM:-2G} \
     JAVA_MIN_MEM=${JAVA_MIN_MEM:-0} \
-    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.7} \
-    IMAGEMAGICK_VERSION=${IMAGEMAGICK_VERSION:-7.0.10-62} \
+    CANTALOUPE_VERSION=${CANTALOUPE_VERSION:-4.1.8} \
+    IMAGEMAGICK_VERSION=${IMAGEMAGICK_VERSION:-7.0.11-3} \
     ## # To use Kakadu instead of OpenJpeg as the processor for uniqe builds - comment out these two lines below and uncomment the lines below the comment "To use Kakadu for unique builds"
     JAVA_OPTS='-Djava.awt.headless=true -server -Xmx${JAVA_MAX_MEM} -Xms${JAVA_MIN_MEM} -XX:+UseG1GC -XX:+UseStringDeduplication -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=70 -Djava.net.preferIPv4Stack=true -Djava.net.preferIPv4Addresses=true' \
     CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Running Cantaloupe as a IIIF compliant image server for ISLE.
 
 Based on:
 * [ISLE-tomcat](https://github.com/Islandora-Collaboration-Group/isle-tomcat)
-* [Cantaloupe 4.1.6](https://medusa-project.github.io/cantaloupe/) an IIIF compliant open-source dynamic image server
+* [Cantaloupe 4.1.x](https://medusa-project.github.io/cantaloupe/) an IIIF compliant open-source dynamic image server
 
 Contains and Includes:
-* [ImageMagick 7](https://www.imagemagick.org/)
+* [ImageMagick 7.x](https://www.imagemagick.org/)
   * Features: Cipher DPC HDRI OpenMP
   * Delegates (built-in): bzlib djvu mpeg fontconfig freetype jbig jng jpeg lcms lqr lzma openexr openjp2 png ps raw rsvg tiff webp wmf x zlib
 * [OpenJPEG](http://www.openjpeg.org/)
@@ -78,11 +78,11 @@ CATALINA_OPTS="-Dcantaloupe.config=/usr/local/cantaloupe/cantaloupe.properties \
 * Open a terminal and either clone down this new git repository to your local laptop or `cd` to the project on your laptop
 
 * Build the image
-  * `docker build -t yourdockerimagerepohere/isle-imageservices:1.5.1 .`
+  * `docker build -t yourdockerimagerepohere/isle-imageservices:1.x.x .`
 
 * Push the image to your docker image repo
-  * `docker push yourdockerimagerepohere/isle-imageservices:1.5.1`
+  * `docker push yourdockerimagerepohere/isle-imageservices:1.x.x`
 
 * Use the newly built image in ISLE
-  * Within all of the `docker-compose.*.yml` files in your ISLE project, change `image: islandoracollabgroup/isle-imageservices:1.5.1` to `image: yourdockerimagerepohere/isle-imageservices:1.5.1`
+  * Within all of the `docker-compose.*.yml` files in your ISLE project, change `image: islandoracollabgroup/isle-imageservices:1.x.x` to `image: yourdockerimagerepohere/isle-imageservices:1.x.x`
   * Save all of the files after editing and check the changes into git.

--- a/rootfs/etc/confd/templates/imageserv/cantaloupe.properties.tpl
+++ b/rootfs/etc/confd/templates/imageserv/cantaloupe.properties.tpl
@@ -463,7 +463,9 @@ cache.server.source = FilesystemCache
 
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.source.ttl_seconds = 2592000
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+cache.server.source.ttl_seconds = 86400
 
 # Enables the derivative (processed image) cache.
 cache.server.derivative.enabled = true
@@ -474,7 +476,9 @@ cache.server.derivative = FilesystemCache
 
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.derivative.ttl_seconds = 2592000
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+cache.server.source.ttl_seconds = 86400
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either
 # independently or in front of a "level 2" derivative cache (if enabled).
@@ -493,11 +497,15 @@ cache.server.resolve_first = false
 
 # !! Enables the cache worker, which periodically purges invalid cache
 # items in the background.
-cache.server.worker.enabled = false
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed to true
+cache.server.worker.enabled = true
 
 # !! The cache worker will wait this many seconds before starting its
 # next shift.
-cache.server.worker.interval = 86400
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 86400 to 43200
+cache.server.worker.interval = 43200
 
 #----------------------------------------
 # FilesystemCache

--- a/rootfs/etc/confd/templates/imageserv/cantaloupe.properties.tpl
+++ b/rootfs/etc/confd/templates/imageserv/cantaloupe.properties.tpl
@@ -464,7 +464,7 @@ cache.server.source = FilesystemCache
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+# Changed from default 259200 (30 days) to 86400 (1 day)
 cache.server.source.ttl_seconds = 86400
 
 # Enables the derivative (processed image) cache.
@@ -477,7 +477,7 @@ cache.server.derivative = FilesystemCache
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+# Changed from default 259200 (30 days) to 86400 (1 day)
 cache.server.source.ttl_seconds = 86400
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either

--- a/rootfs/usr/local/cantaloupe/cantaloupe.properties
+++ b/rootfs/usr/local/cantaloupe/cantaloupe.properties
@@ -464,7 +464,7 @@ cache.server.source = FilesystemCache
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+# Changed from default 259200 (30 days) to 86400 (1 day)
 cache.server.source.ttl_seconds = 86400
 
 # Enables the derivative (processed image) cache.
@@ -477,7 +477,7 @@ cache.server.derivative = FilesystemCache
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+# Changed from default 259200 (30 days) to 86400 (1 day)
 cache.server.source.ttl_seconds = 86400
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either

--- a/rootfs/usr/local/cantaloupe/cantaloupe.properties
+++ b/rootfs/usr/local/cantaloupe/cantaloupe.properties
@@ -464,8 +464,8 @@ cache.server.source = FilesystemCache
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 to 900
-cache.server.source.ttl_seconds = 900
+# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+cache.server.source.ttl_seconds = 86400
 
 # Enables the derivative (processed image) cache.
 cache.server.derivative.enabled = true
@@ -477,8 +477,8 @@ cache.server.derivative = FilesystemCache
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
 # Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
-# Changed this from default 259200 to 900
-cache.server.source.ttl_seconds = 900
+# Changed this from default 259200 (30 days)_ to 86400 (1 day)
+cache.server.source.ttl_seconds = 86400
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either
 # independently or in front of a "level 2" derivative cache (if enabled).

--- a/rootfs/usr/local/cantaloupe/cantaloupe.properties
+++ b/rootfs/usr/local/cantaloupe/cantaloupe.properties
@@ -463,7 +463,9 @@ cache.server.source = FilesystemCache
 
 # Amount of time source cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.source.ttl_seconds = 2592000
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 259200 to 900
+cache.server.source.ttl_seconds = 900
 
 # Enables the derivative (processed image) cache.
 cache.server.derivative.enabled = true
@@ -474,7 +476,9 @@ cache.server.derivative = FilesystemCache
 
 # Amount of time derivative cache content remains valid. Set to blank or 0
 # for forever.
-cache.server.derivative.ttl_seconds = 2592000
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 259200 to 900
+cache.server.source.ttl_seconds = 900
 
 # Whether to use the Java heap as a "level 1" cache for image infos, either
 # independently or in front of a "level 2" derivative cache (if enabled).
@@ -493,11 +497,15 @@ cache.server.resolve_first = false
 
 # !! Enables the cache worker, which periodically purges invalid cache
 # items in the background.
-cache.server.worker.enabled = false
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed to true
+cache.server.worker.enabled = true
 
 # !! The cache worker will wait this many seconds before starting its
 # next shift.
-cache.server.worker.interval = 86400
+# Per https://github.com/Islandora-Collaboration-Group/ISLE/issues/207
+# Changed this from default 86400 to 43200
+cache.server.worker.interval = 43200
 
 #----------------------------------------
 # FilesystemCache


### PR DESCRIPTION
Reference https://github.com/Islandora-Collaboration-Group/ISLE/projects/5

* Release fixes
  * https://github.com/Islandora-Collaboration-Group/ISLE/issues/207